### PR TITLE
Remove steem from Python dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(name="tinman",
       url              = "https://github.com/steemit/tinman",
       author           = "Steemit",
       packages         = ["tinman"],
-      install_requires = ["steem"],
+      install_requires = [],
       entry_points     = {"console_scripts" : [
                           "tinman=tinman.main:sys_main",
                          ]}


### PR DESCRIPTION
PR somewhat related to already-closed issue #26.  We don't actually use it and it requires Python 3.6, which is inconvenient because it isn't in the Ubuntu repo and we have to compile it from source.  Let's get rid of the dependency instead.
