### PR TITLE
99 refactor txgen

### DIFF
--- a/txgen.conf.example
+++ b/txgen.conf.example
@@ -4,7 +4,7 @@
  "snapshot_file" : "snapshot.json",
 
  "min_vesting_per_account" : {"amount" : "1", "precision" : 3, "nai" : "@@000000021"},
- "total_port_balance" : {"amount" : "200000000000", "precision" : 3, "nai" : "@@000000021"},
+ "total_port_balance" : {"amount" : "400000000000", "precision" : 3, "nai" : "@@000000021"},
 
  "accounts" :
  {


### PR DESCRIPTION
I have high confidence that this closes #99 without introducing any differences in the actions.

```diff
$ diff --speed-large-files a b
1c1
< ["wait_blocks",{"count":1,"esc":"d","miss_blocks":27963321}]
---
> ["wait_blocks",{"count":1,"esc":"d","miss_blocks":27960112}]
```

Only the first line is different, and this is still based on 1.4 GB of actions.  File `a` comes from the output of `master` and `b` comes from this branch.